### PR TITLE
per issue #7

### DIFF
--- a/crazyflie_driver/CMakeLists.txt
+++ b/crazyflie_driver/CMakeLists.txt
@@ -147,6 +147,8 @@ add_dependencies(crazyflie_add
   crazyflie_driver_generate_messages_cpp
 )
 
+add_dependencies(crazyflie_add ${${PROJECT_NAME}}_EXPORTED_TARGETS ${catkin_EXPORTED_TARGETS})
+
 target_link_libraries(crazyflie_add
   ${catkin_LIBRARIES}
 )

--- a/crazyflie_manager/CMakeLists.txt
+++ b/crazyflie_manager/CMakeLists.txt
@@ -12,6 +12,7 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 ## System dependencies are found with CMake's conventions
 # find_package(Eigen3 REQUIRED)
 # find_package(Boost REQUIRED COMPONENTS system)
+find_package(crazyflie_driver REQUIRED)
 
 
 ## Uncomment this if the package has a setup.py. This macro ensures


### PR DESCRIPTION
Fixes for items 3 and 4 in [issue 4](https://github.com/USC-ACTLab/crazyswarm/issues/7#issuecomment-302970012):

[x] Fixes  getting manager.cpp within crazyflie_manager locating crazyflie_driver. Crazyflie_driver is listed as a `crazyflie_manager` `catkin_DEPENDS` and is also listed in the package manifest list but it is not `find_packaged`. This `find_packages` `crazyflie_driver`.

[x] `manager.cpp` in `crazyflie_manager` depends on `crazyflie_driver`, yet it is not specified as a `catkin_exported_targets` dependency in the `crazyflie_manager` package. This meant header files compilable from `srv/msg` files were not found with `catkin_make` during the process of compilation (since `catkin_make` is a parallel compilation tool). To allow message generation targets to be built before any programs that depend on them, this declares an explicit dependencies in `crazyflie_driver`'s `CMakeLists.txt` i.e.

`add_dependencies(crazyflie_add ${${PROJECT_NAME}}_EXPORTED_TARGETS ${catkin_EXPORTED_TARGETS})`

following the catkin 0.6.1 direction i.e.,

> every target that directly or indirectly uses one of your message headers must declare an explicit dependency.